### PR TITLE
Optimization of SeparateSubclassVisitor

### DIFF
--- a/src/FluentNHibernate.Testing/PersistenceModelTests/SeparateSubclassVisitorFixture.cs
+++ b/src/FluentNHibernate.Testing/PersistenceModelTests/SeparateSubclassVisitorFixture.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using FluentNHibernate.Mapping;
 using FluentNHibernate.Mapping.Providers;
@@ -13,13 +11,13 @@ namespace FluentNHibernate.Testing.PersistenceModelTests
     [TestFixture]
     public class SeparateSubclassVisitorFixture
     {
-        private IList<IIndeterminateSubclassMappingProvider> providers;
+        private IIndeterminateSubclassMappingProviderCollection providers;
         private ClassMapping fooMapping;
 
         [SetUp]
         public void SetUp()
         {
-            providers = new List<IIndeterminateSubclassMappingProvider>();
+            providers = new IndeterminateSubclassMappingProviderCollection();
         }
 
         [Test]

--- a/src/FluentNHibernate/FluentNHibernate.csproj
+++ b/src/FluentNHibernate/FluentNHibernate.csproj
@@ -425,7 +425,9 @@
     <Compile Include="Mapping\NaturalIdPart.cs" />
     <Compile Include="Mapping\Providers\IElementMappingProvider.cs" />
     <Compile Include="Mapping\Providers\IExternalComponentMappingProvider.cs" />
+    <Compile Include="Mapping\Providers\IIndeterminateSubclassMappingProviderCollection.cs" />
     <Compile Include="Mapping\Providers\INaturalIdMappingProvider.cs" />
+    <Compile Include="Mapping\Providers\IndeterminateSubclassMappingProviderCollection.cs" />
     <Compile Include="Mapping\Providers\INestedCompositeElementMappingProvider.cs" />
     <Compile Include="Mapping\Providers\IPropertyMappingProvider.cs" />
     <Compile Include="Mapping\Providers\IReferenceComponentMappingProvider.cs" />

--- a/src/FluentNHibernate/Mapping/Providers/IIndeterminateSubclassMappingProviderCollection.cs
+++ b/src/FluentNHibernate/Mapping/Providers/IIndeterminateSubclassMappingProviderCollection.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+
+namespace FluentNHibernate.Mapping.Providers
+{
+    public interface IIndeterminateSubclassMappingProviderCollection : IEnumerable<IIndeterminateSubclassMappingProvider>
+    {        
+        void Add(IIndeterminateSubclassMappingProvider item);
+        bool IsTypeMapped(Type type);
+    }
+}

--- a/src/FluentNHibernate/Mapping/Providers/IndeterminateSubclassMappingProviderCollection.cs
+++ b/src/FluentNHibernate/Mapping/Providers/IndeterminateSubclassMappingProviderCollection.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace FluentNHibernate.Mapping.Providers
+{
+    /// <summary>
+    /// This collection optimizes search for already mapped types in subclasses providers. Matters in models with huge inheritance trees.
+    /// </summary>
+    public class IndeterminateSubclassMappingProviderCollection : IIndeterminateSubclassMappingProviderCollection
+    {
+        private readonly List<IIndeterminateSubclassMappingProvider> providers = new List<IIndeterminateSubclassMappingProvider>(); 
+        private readonly HashSet<Type> mappedTypes = new HashSet<Type>(); 
+
+        public IEnumerator<IIndeterminateSubclassMappingProvider> GetEnumerator()
+        {
+            return providers.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public void Add(IIndeterminateSubclassMappingProvider item)
+        {
+            providers.Add(item);
+            mappedTypes.Add(item.EntityType);
+        }
+
+        public bool IsTypeMapped(Type type)
+        {
+            return mappedTypes.Contains(type);
+        }
+    }
+}

--- a/src/FluentNHibernate/PersistenceModel.cs
+++ b/src/FluentNHibernate/PersistenceModel.cs
@@ -24,7 +24,7 @@ namespace FluentNHibernate
     {
         protected readonly IList<IMappingProvider> classProviders = new List<IMappingProvider>();
         protected readonly IList<IFilterDefinition> filterDefinitions = new List<IFilterDefinition>();
-        protected readonly IList<IIndeterminateSubclassMappingProvider> subclassProviders = new List<IIndeterminateSubclassMappingProvider>();
+        protected readonly IIndeterminateSubclassMappingProviderCollection subclassProviders = new IndeterminateSubclassMappingProviderCollection();
         protected readonly IList<IExternalComponentMappingProvider> componentProviders = new List<IExternalComponentMappingProvider>();
         protected readonly IList<IComponentReferenceResolver> componentResolvers = new List<IComponentReferenceResolver>
         {

--- a/src/FluentNHibernate/Visitors/SeparateSubclassVisitor.cs
+++ b/src/FluentNHibernate/Visitors/SeparateSubclassVisitor.cs
@@ -9,9 +9,9 @@ namespace FluentNHibernate.Visitors
 {
     public class SeparateSubclassVisitor : DefaultMappingModelVisitor
     {
-        private readonly IList<IIndeterminateSubclassMappingProvider> subclassProviders;
+        private readonly IIndeterminateSubclassMappingProviderCollection subclassProviders;
 
-        public SeparateSubclassVisitor(IList<IIndeterminateSubclassMappingProvider> subclassProviders)
+        public SeparateSubclassVisitor(IIndeterminateSubclassMappingProviderCollection subclassProviders)
         {
             this.subclassProviders = subclassProviders;
         }
@@ -65,9 +65,9 @@ namespace FluentNHibernate.Visitors
             return SubclassType.Subclass;
         }
 
-        private bool IsMapped(Type type, IEnumerable<IIndeterminateSubclassMappingProvider> providers)
+        private bool IsMapped(Type type, IIndeterminateSubclassMappingProviderCollection providers)
         {
-            return providers.Any(x => x.EntityType == type);
+            return providers.IsTypeMapped(type);
         }
 
         /// <summary>


### PR DESCRIPTION
Hi!
We have rather big code-first NH-model in our project with thousand classes and long hierarchy chains.
Testing showed that from two to five minutes are spent on bulding model. Profiling showed thant 70% time is spent in FluentNHibernate, particulary in SeparateSubclassVisitor.IsMapped method. 
I suggest a performance fix that optimizes this method. Now our model builds in less than one minute and most time is spent in NH itself.
We are already using this patched version in our project, but it is likely to have it merged with FNH master for updating reasons.
Any comments are welcome, if you need a model and prototype-project with this properties we can provide it.