### PR TITLE
Remove references to non-existent files

### DIFF
--- a/src/FluentNHibernate.Testing/FluentNHibernate.Testing.csproj
+++ b/src/FluentNHibernate.Testing/FluentNHibernate.Testing.csproj
@@ -67,9 +67,6 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\CommonAssemblyInfo.cs">
-      <Link>CommonAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="AutoMapping\Apm\AbstractBaseClassTests.cs" />
     <Compile Include="AutoMapping\Apm\AlterationCollectionTests.cs" />
     <Compile Include="AutoMapping\Apm\AlterationTests.cs" />

--- a/src/FluentNHibernate/FluentNHibernate.csproj
+++ b/src/FluentNHibernate/FluentNHibernate.csproj
@@ -59,9 +59,6 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\CommonAssemblyInfo.cs">
-      <Link>CommonAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="Automapping\Alterations\AutoMappingOverrideAlteration.cs" />
     <Compile Include="Automapping\Alterations\IAutoMappingAlteration.cs" />
     <Compile Include="Automapping\Alterations\IAutoMappingOverride.cs" />


### PR DESCRIPTION
Remove references to the non-existent file CommonAssemblyInfo.cs in the FluentNHibernate and FluentNHibernate.Testing projects

Resolves issue #308 