### PR TITLE
Improper matching performed in RelationshipPairingVisitor's PairOneToManys

### DIFF
--- a/RakeFile
+++ b/RakeFile
@@ -72,7 +72,8 @@ namespace :source do
     info.product_name = 'FluentNHibernate'
     info.description = commit_hash[0..(commit_hash.length - 3)]
     info.copyright = "Copyright 2008-#{Time.new.year} James Gregory and contributors (Paul Batum, Hudson Akridge et al). All rights reserved."
-    info.namespaces = ['System.Security']
+    info.namespaces = ['System.Security','System.Runtime.CompilerServices']
+    info.custom_attributes :InternalsVisibleTo => "FluentNHibernate.Testing"
     
     puts "The new version is #{info.version}"
   end

--- a/src/FluentNHibernate.Testing/FluentNHibernate.Testing.csproj
+++ b/src/FluentNHibernate.Testing/FluentNHibernate.Testing.csproj
@@ -394,6 +394,8 @@
     <Compile Include="Utils\TypeReferenceEqualityTests.cs" />
     <Compile Include="Visitors\ComponentColumnPrefixVisitorSpecs.cs" />
     <Compile Include="Visitors\ComponentReferenceResolutionVisitorSpecs.cs" />
+    <Compile Include="Visitors\RelationshipPairingVisitorSpec.cs" />
+    <Compile Include="Visitors\RelationshipPairingVisitorSpecSupportClasses.cs" />
     <Compile Include="Xml\MappingXmlTestHelper.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/FluentNHibernate.Testing/Visitors/RelationshipPairingVisitorSpec.cs
+++ b/src/FluentNHibernate.Testing/Visitors/RelationshipPairingVisitorSpec.cs
@@ -1,0 +1,60 @@
+using System.Linq;
+using FakeItEasy;
+using FluentNHibernate.MappingModel;
+using FluentNHibernate.MappingModel.Collections;
+using FluentNHibernate.Visitors;
+using NUnit.Framework;
+
+namespace FluentNHibernate.Testing.Visitors
+{
+    public abstract class RelationshipPairingVisitorSpec : Specification
+    {
+        protected RelationshipPairingVisitor visitor;
+        protected CollectionMapping collectionMappingToZ;
+        protected ManyToOneMapping manyToOneZToHolder;
+        protected ManyToOneMapping manyToOneYToHolder;
+    }
+
+    [TestFixture]
+    public class when_the_relationship_pairing_visitor_visits_with_multiple_many_to_one_mapping_references : RelationshipPairingVisitorSpec
+    {
+        public override void establish_context()
+        {
+            manyToOneYToHolder = new ManyToOneMapping();
+            manyToOneYToHolder.Set(x => x.Class, Layer.Defaults, new TypeReference(typeof(Holder)));
+            manyToOneYToHolder.Set(x => x.Name, Layer.Defaults, "ARankedFirstProperty");
+            manyToOneYToHolder.ContainingEntityType = typeof(ARankedFirst);
+            manyToOneYToHolder.Member = new PropertyMember(typeof(ARankedFirst).GetProperty("ARankedFirstProperty"));
+
+            manyToOneZToHolder = new ManyToOneMapping();
+            manyToOneZToHolder.Set(x => x.Class, Layer.Defaults, new TypeReference(typeof(Holder)));
+            manyToOneZToHolder.Set(x => x.Name, Layer.Defaults, "BRankedSecondProperty");
+            manyToOneZToHolder.ContainingEntityType = typeof(BRankedSecond);
+            manyToOneZToHolder.Member = new PropertyMember(typeof(BRankedSecond).GetProperty("BRankedSecondProperty"));
+
+            var relationship = new OneToManyMapping();
+            relationship.Set(x => x.Class, Layer.Defaults, new TypeReference(typeof(BRankedSecond)));
+            relationship.ContainingEntityType = typeof(Holder);
+
+            collectionMappingToZ = CollectionMapping.Bag();
+            collectionMappingToZ.Set(x => x.ChildType, Layer.Defaults, typeof(BRankedSecond));
+            collectionMappingToZ.Set(x => x.Name, Layer.Defaults, "ColectionOfBRankedSeconds");
+            collectionMappingToZ.Set(x => x.Relationship, Layer.Defaults, relationship);
+            collectionMappingToZ.ContainingEntityType = typeof(Holder);
+
+            visitor = new RelationshipPairingVisitor(A.Fake<PairBiDirectionalManyToManySidesDelegate>());
+        }
+
+        [Test]
+        public void should_associate_the_collection_mapping_to_the_correct_type()
+        {
+            visitor.ProcessCollection(collectionMappingToZ);
+            visitor.ProcessManyToOne(manyToOneYToHolder);
+            visitor.ProcessManyToOne(manyToOneZToHolder);
+            visitor.Visit(Enumerable.Empty<HibernateMapping>());
+
+            var otherSide = (ManyToOneMapping)collectionMappingToZ.OtherSide;
+            otherSide.ContainingEntityType.ShouldEqual(typeof(BRankedSecond));
+        }
+    }
+}

--- a/src/FluentNHibernate.Testing/Visitors/RelationshipPairingVisitorSpec.cs
+++ b/src/FluentNHibernate.Testing/Visitors/RelationshipPairingVisitorSpec.cs
@@ -7,40 +7,37 @@ using NUnit.Framework;
 
 namespace FluentNHibernate.Testing.Visitors
 {
-    public abstract class RelationshipPairingVisitorSpec : Specification
+    [TestFixture]
+    public class when_the_relationship_pairing_visitor_visits_with_multiple_many_to_one_mapping_references : Specification
     {
         protected RelationshipPairingVisitor visitor;
-        protected CollectionMapping collectionMappingToZ;
-        protected ManyToOneMapping manyToOneZToHolder;
-        protected ManyToOneMapping manyToOneYToHolder;
-    }
+        protected CollectionMapping collectionMappingToBRankedSecond;
+        protected ManyToOneMapping manyToOneBRankedSecondToHolder;
+        protected ManyToOneMapping manyToOneARankedFirstToHolder;
 
-    [TestFixture]
-    public class when_the_relationship_pairing_visitor_visits_with_multiple_many_to_one_mapping_references : RelationshipPairingVisitorSpec
-    {
         public override void establish_context()
         {
-            manyToOneYToHolder = new ManyToOneMapping();
-            manyToOneYToHolder.Set(x => x.Class, Layer.Defaults, new TypeReference(typeof(Holder)));
-            manyToOneYToHolder.Set(x => x.Name, Layer.Defaults, "ARankedFirstProperty");
-            manyToOneYToHolder.ContainingEntityType = typeof(ARankedFirst);
-            manyToOneYToHolder.Member = new PropertyMember(typeof(ARankedFirst).GetProperty("ARankedFirstProperty"));
+            manyToOneARankedFirstToHolder = new ManyToOneMapping();
+            manyToOneARankedFirstToHolder.Set(x => x.Class, Layer.Defaults, new TypeReference(typeof(Holder)));
+            manyToOneARankedFirstToHolder.Set(x => x.Name, Layer.Defaults, "ARankedFirstProperty");
+            manyToOneARankedFirstToHolder.ContainingEntityType = typeof(ARankedFirst);
+            manyToOneARankedFirstToHolder.Member = new PropertyMember(typeof(ARankedFirst).GetProperty("ARankedFirstProperty"));
 
-            manyToOneZToHolder = new ManyToOneMapping();
-            manyToOneZToHolder.Set(x => x.Class, Layer.Defaults, new TypeReference(typeof(Holder)));
-            manyToOneZToHolder.Set(x => x.Name, Layer.Defaults, "BRankedSecondProperty");
-            manyToOneZToHolder.ContainingEntityType = typeof(BRankedSecond);
-            manyToOneZToHolder.Member = new PropertyMember(typeof(BRankedSecond).GetProperty("BRankedSecondProperty"));
+            manyToOneBRankedSecondToHolder = new ManyToOneMapping();
+            manyToOneBRankedSecondToHolder.Set(x => x.Class, Layer.Defaults, new TypeReference(typeof(Holder)));
+            manyToOneBRankedSecondToHolder.Set(x => x.Name, Layer.Defaults, "BRankedSecondProperty");
+            manyToOneBRankedSecondToHolder.ContainingEntityType = typeof(BRankedSecond);
+            manyToOneBRankedSecondToHolder.Member = new PropertyMember(typeof(BRankedSecond).GetProperty("BRankedSecondProperty"));
 
             var relationship = new OneToManyMapping();
             relationship.Set(x => x.Class, Layer.Defaults, new TypeReference(typeof(BRankedSecond)));
             relationship.ContainingEntityType = typeof(Holder);
 
-            collectionMappingToZ = CollectionMapping.Bag();
-            collectionMappingToZ.Set(x => x.ChildType, Layer.Defaults, typeof(BRankedSecond));
-            collectionMappingToZ.Set(x => x.Name, Layer.Defaults, "ColectionOfBRankedSeconds");
-            collectionMappingToZ.Set(x => x.Relationship, Layer.Defaults, relationship);
-            collectionMappingToZ.ContainingEntityType = typeof(Holder);
+            collectionMappingToBRankedSecond = CollectionMapping.Bag();
+            collectionMappingToBRankedSecond.Set(x => x.ChildType, Layer.Defaults, typeof(BRankedSecond));
+            collectionMappingToBRankedSecond.Set(x => x.Name, Layer.Defaults, "ColectionOfBRankedSeconds");
+            collectionMappingToBRankedSecond.Set(x => x.Relationship, Layer.Defaults, relationship);
+            collectionMappingToBRankedSecond.ContainingEntityType = typeof(Holder);
 
             visitor = new RelationshipPairingVisitor(A.Fake<PairBiDirectionalManyToManySidesDelegate>());
         }
@@ -48,12 +45,12 @@ namespace FluentNHibernate.Testing.Visitors
         [Test]
         public void should_associate_the_collection_mapping_to_the_correct_type()
         {
-            visitor.ProcessCollection(collectionMappingToZ);
-            visitor.ProcessManyToOne(manyToOneYToHolder);
-            visitor.ProcessManyToOne(manyToOneZToHolder);
+            visitor.ProcessCollection(collectionMappingToBRankedSecond);
+            visitor.ProcessManyToOne(manyToOneARankedFirstToHolder);
+            visitor.ProcessManyToOne(manyToOneBRankedSecondToHolder);
             visitor.Visit(Enumerable.Empty<HibernateMapping>());
 
-            var otherSide = (ManyToOneMapping)collectionMappingToZ.OtherSide;
+            var otherSide = (ManyToOneMapping)collectionMappingToBRankedSecond.OtherSide;
             otherSide.ContainingEntityType.ShouldEqual(typeof(BRankedSecond));
         }
     }

--- a/src/FluentNHibernate.Testing/Visitors/RelationshipPairingVisitorSpecSupportClasses.cs
+++ b/src/FluentNHibernate.Testing/Visitors/RelationshipPairingVisitorSpecSupportClasses.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+
+namespace FluentNHibernate.Testing.Visitors
+{
+    public class Holder
+    {
+        public virtual ICollection<BRankedSecond> ColectionOfBRankedSeconds { get; set; }
+    }
+
+    public class BRankedSecond
+    {
+        public virtual Holder BRankedSecondProperty { get; set; }
+    }
+
+    public class ARankedFirst
+    {
+        public virtual Holder ARankedFirstProperty { get; set; }
+    }
+}

--- a/src/FluentNHibernate/Visitors/RelationshipPairingVisitor.cs
+++ b/src/FluentNHibernate/Visitors/RelationshipPairingVisitor.cs
@@ -49,7 +49,12 @@ namespace FluentNHibernate.Visitors
             foreach (var collection in orderedCollections)
             {
                 var type = collection.ContainingEntityType;
-                var reference = orderedRefs.FirstOrDefault(x => x.OtherSide == null && x.Class.GetUnderlyingSystemType() == type);
+                var childType = collection.ChildType;
+                var reference = orderedRefs
+                    .FirstOrDefault(x => 
+                        x.OtherSide == null && 
+                        x.Class.GetUnderlyingSystemType() == type &&
+                        x.ContainingEntityType == childType);
 
                 if (reference == null) continue;
 


### PR DESCRIPTION
An entity (A) with a one to many collection pointing to an entity (B) that has the corresponding many to one reference back (to A) may in some cases be pared incorrectly.

If another entity (C) has a many to one reference back to the original entity (A), but (A) has no collection for (C) then when attempting to pair (A->B) we can actually get (A->C).

This happens when (C)s property to (A) has a name which alphabetically before (B)s property to (A).

I have provided a fix and a test, the test may need modification as it requires `PropertyMember` and hence the added `InternalsVisibleTo` in the RakeFile. 

If the fix is approved, I am in need of the fix to be cherry-picked back into 1.4, thank you.