### PR TITLE
Relationship pairing fixes (matching one-to-many relationship ends and foreign key column naming)

### DIFF
--- a/src/FluentNHibernate.Testing/FluentNHibernate.Testing.csproj
+++ b/src/FluentNHibernate.Testing/FluentNHibernate.Testing.csproj
@@ -394,6 +394,7 @@
     <Compile Include="Utils\TypeReferenceEqualityTests.cs" />
     <Compile Include="Visitors\ComponentColumnPrefixVisitorSpecs.cs" />
     <Compile Include="Visitors\ComponentReferenceResolutionVisitorSpecs.cs" />
+    <Compile Include="Visitors\RelationshipPairingSpec.cs" />
     <Compile Include="Xml\MappingXmlTestHelper.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/FluentNHibernate.Testing/Visitors/RelationshipPairingSpec.cs
+++ b/src/FluentNHibernate.Testing/Visitors/RelationshipPairingSpec.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using FluentNHibernate.Automapping;
+using FluentNHibernate.Diagnostics;
+using FluentNHibernate.MappingModel;
+using FluentNHibernate.MappingModel.Collections;
+using NUnit.Framework;
+using System.Linq;
+
+namespace FluentNHibernate.Testing.Visitors
+{
+    [TestFixture]
+    public class when_there_is_any_unpaired_collection_property_alphabetically_before_collection_property_which_has_corresponding_back_reference_from_child : RelationshipPairingSpec
+    {
+        CollectionMapping collectionWithoutBackrefAndAlphabeticallyFirst;
+        CollectionMapping collectionWithoutBackrefAndAlphabeticallyLast;
+        CollectionMapping collectionWithCorrespondingBackref;
+        ManyToOneMapping referenceFromChildSecondTypeToParent;
+
+        public override void establish_context()
+        {
+            var autoPersistenceModel = AutoMap.Source(new Types(), new AutomappingConfiguration());
+            var hibernateMappings = autoPersistenceModel.BuildMappings();
+
+            var classMapping = hibernateMappings.SelectMany(h => h.Classes).Single(c => c.Type == typeof(Parent));
+            collectionWithoutBackrefAndAlphabeticallyFirst = classMapping.Collections.Single(c => c.ChildType == typeof(ChildFirstType));
+            collectionWithCorrespondingBackref = classMapping.Collections.Single(c => c.ChildType == typeof(ChildSecondType));
+            collectionWithoutBackrefAndAlphabeticallyLast = classMapping.Collections.Single(c => c.ChildType == typeof(ChildThirdType));
+        }
+
+        public override void because()
+        {
+
+        }
+
+        [Test]
+        public void should_pair_with_corresponding_property()
+        {
+            collectionWithoutBackrefAndAlphabeticallyFirst.OtherSide.ShouldBeNull();
+            collectionWithCorrespondingBackref.OtherSide.ShouldNotBeNull();
+        }
+    }
+
+    [TestFixture]
+    public class when_relation_has_two_ends : RelationshipPairingSpec
+    {
+        CollectionMapping collectionWithCorrespondingBackref;
+        ManyToOneMapping referenceFromChildSecondTypeToParent;
+
+        public override void establish_context()
+        {
+            var autoPersistenceModel = AutoMap.Source(new Types(), new AutomappingConfiguration());
+            var hibernateMappings = autoPersistenceModel.BuildMappings();
+
+            var classMapping = hibernateMappings.SelectMany(h => h.Classes).Single(c => c.Type == typeof(Parent));
+            collectionWithCorrespondingBackref = classMapping.Collections.Single(c => c.ChildType == typeof(ChildSecondType));
+        }
+
+        public override void because()
+        {
+
+        }
+
+        [Test]
+        public void should_use_single_foreign_key_column()
+        {
+            var columnMappingFromParentSide = collectionWithCorrespondingBackref.Key.Columns.Single();
+            var columnMappingFromChildSide = ((ManyToOneMapping)collectionWithCorrespondingBackref.OtherSide).Columns.Single();
+
+            columnMappingFromParentSide.Name.ShouldEqual(columnMappingFromChildSide.Name);
+        }
+    }
+
+    public abstract class RelationshipPairingSpec : Specification
+    {
+        protected class Types : ITypeSource
+        {
+            public IEnumerable<Type> GetTypes()
+            {
+                return new[] { typeof(Parent), typeof(ChildFirstType), typeof(ChildSecondType), typeof(ChildThirdType) };
+            }
+
+            public void LogSource(IDiagnosticLogger logger)
+            { }
+
+            public string GetIdentifier()
+            {
+                return "3C423683-08F3-4FD8-9B9C-A043B11C52B5";
+            }
+        }
+
+        protected class AutomappingConfiguration : DefaultAutomappingConfiguration
+        {
+            public override bool ShouldMap(Type type)
+            {
+                return true;
+            }
+        }
+
+        protected class Parent
+        {
+            public int Id { get; set; }
+            public string Property { get; set; }
+            public IList<ChildFirstType> AChildrenOfFirstType { get; set; }
+            public IList<ChildSecondType> BChildrenOfSecondType { get; set; }
+            public IList<ChildThirdType> CChildrenOfThirdType { get; set; }
+        }
+
+        protected class ChildFirstType
+        {
+            public int Id { get; set; }
+            public string Property { get; set; }
+        }
+
+        protected class ChildSecondType
+        {
+            public int Id { get; set; }
+            public string Property { get; set; }
+            public Parent MyParent { get; set; }
+        }
+
+        protected class ChildThirdType
+        {
+            public int Id { get; set; }
+            public string Property { get; set; }
+        }
+
+    }
+}

--- a/src/FluentNHibernate/Visitors/RelationshipKeyPairingVisitor.cs
+++ b/src/FluentNHibernate/Visitors/RelationshipKeyPairingVisitor.cs
@@ -14,12 +14,8 @@ namespace FluentNHibernate.Visitors
             // other side is always going to be a collection for a many-to-one mapping
             var otherSide = (CollectionMapping)thisSide.OtherSide;
 
-            if (thisSide.ContainingEntityType == otherSide.ContainingEntityType)
-            {
-                // special case for self-referential relationships
-                otherSide.Key.MakeColumnsEmpty(Layer.Defaults);
-                thisSide.Columns.Each(x => otherSide.Key.AddColumn(Layer.Defaults, x.Clone()));
-            }
+            otherSide.Key.MakeColumnsEmpty(Layer.Defaults);
+            thisSide.Columns.Each(x => otherSide.Key.AddColumn(Layer.Defaults, x.Clone()));
         }
     }
 }

--- a/src/FluentNHibernate/Visitors/RelationshipPairingVisitor.cs
+++ b/src/FluentNHibernate/Visitors/RelationshipPairingVisitor.cs
@@ -49,7 +49,7 @@ namespace FluentNHibernate.Visitors
             foreach (var collection in orderedCollections)
             {
                 var type = collection.ContainingEntityType;
-                var reference = orderedRefs.FirstOrDefault(x => x.OtherSide == null && x.Class.GetUnderlyingSystemType() == type);
+                var reference = orderedRefs.FirstOrDefault(x => x.OtherSide == null && x.Class.GetUnderlyingSystemType() == type && x.ContainingEntityType == collection.ChildType);
 
                 if (reference == null) continue;
 
@@ -166,7 +166,7 @@ namespace FluentNHibernate.Visitors
         static CollectionMapping PairExactMatches(IEnumerable<CollectionMapping> rs, CollectionMapping current, IEnumerable<CollectionMapping> potentialOtherSides)
         {
             var otherSide = potentialOtherSides.Single();
-                
+
             // got the other side of the relationship
             // lets make sure that the side that we're on now (mapping!)
             // is actually the relationship we want


### PR DESCRIPTION
2 problems fixed: 
1. Bad logic pairing two end of the relation.
It was based on alphabetical order of the propertiess.

2. Wrong foreign key column naming for 2-ended relationships.
Even if 2 end of the relation are properly detected there were created 2 foreign key columns on the many side. It worked properly only when reference property from child to parent was named: [parentTypeName].

PS: I just found that 1. problem is fixed by https://github.com/jagregory/fluent-nhibernate/pull/313 ...
Fortunately fix is the same as proposed here.