### PR TITLE
Changed several ComponentMapping with IComponentMapping

### DIFF
--- a/src/FluentNHibernate/Conventions/Inspections/ComponentBaseInspector.cs
+++ b/src/FluentNHibernate/Conventions/Inspections/ComponentBaseInspector.cs
@@ -10,9 +10,9 @@ namespace FluentNHibernate.Conventions.Inspections
 {
     public abstract class ComponentBaseInspector : IComponentBaseInspector
     {
-        private readonly ComponentMapping mapping;
+        private readonly IComponentMapping mapping;
 
-        public ComponentBaseInspector(ComponentMapping mapping)
+        public ComponentBaseInspector(IComponentMapping mapping)
         {
             this.mapping = mapping;
         }
@@ -88,9 +88,9 @@ namespace FluentNHibernate.Conventions.Inspections
                     .Select(x =>
                     {
                         if (x.ComponentType == ComponentType.Component)
-                            return (IComponentBaseInspector)new ComponentInspector((ComponentMapping)x);
+                            return (IComponentBaseInspector)new ComponentInspector(x);
 
-                        return (IComponentBaseInspector)new DynamicComponentInspector((ComponentMapping)x);
+                        return (IComponentBaseInspector)new DynamicComponentInspector(x);
                     });
             }
         }

--- a/src/FluentNHibernate/Conventions/Inspections/ComponentInspector.cs
+++ b/src/FluentNHibernate/Conventions/Inspections/ComponentInspector.cs
@@ -7,9 +7,9 @@ namespace FluentNHibernate.Conventions.Inspections
     public class ComponentInspector : ComponentBaseInspector, IComponentInspector
     {
         private readonly InspectorModelMapper<IComponentInspector, ComponentMapping> mappedProperties = new InspectorModelMapper<IComponentInspector, ComponentMapping>();
-        private readonly ComponentMapping mapping;
+        private readonly IComponentMapping mapping;
 
-        public ComponentInspector(ComponentMapping mapping)
+        public ComponentInspector(IComponentMapping mapping)
             : base(mapping)
         {
             this.mapping = mapping;

--- a/src/FluentNHibernate/Conventions/Inspections/DynamicComponentInspector.cs
+++ b/src/FluentNHibernate/Conventions/Inspections/DynamicComponentInspector.cs
@@ -7,9 +7,9 @@ namespace FluentNHibernate.Conventions.Inspections
     public class DynamicComponentInspector : ComponentBaseInspector, IDynamicComponentInspector
     {
         private readonly InspectorModelMapper<IDynamicComponentInspector, ComponentMapping> mappedProperties = new InspectorModelMapper<IDynamicComponentInspector, ComponentMapping>();
-        private readonly ComponentMapping mapping;
+        private readonly IComponentMapping mapping;
 
-        public DynamicComponentInspector(ComponentMapping mapping)
+        public DynamicComponentInspector(IComponentMapping mapping)
             : base(mapping)
         {
             this.mapping = mapping;


### PR DESCRIPTION
When using `ComponentBaseInspector.Components` I got the following

```
Unable to cast object of type 'FluentNHibernate.MappingModel.ClassBased.ReferenceComponentMapping' to type 'FluentNHibernate.MappingModel.ClassBased.ComponentMapping
```
I wasn't sure if `ReferenceComponentMapping` should derive from `ComponentMapping` or not so I left that alone. Instead I've changed several `ComponentMapping` to `IComponentMapping` so that no casting was needed.

I ran the rake tests and tested the built DLL in my employer's code.